### PR TITLE
Remove support for system tags

### DIFF
--- a/aws-resourceexplorer2-index/src/main/java/software/amazon/resourceexplorer2/index/TagTools.java
+++ b/aws-resourceexplorer2-index/src/main/java/software/amazon/resourceexplorer2/index/TagTools.java
@@ -36,16 +36,6 @@ public class TagTools {
             tagMap.putAll(resourceModel.getTags());
         }
 
-        // CloudFormation System Tags (SystemTags) are automatically created,
-        // but we need to add them separately.
-       if (request.getSystemTags() != null) {
-           tagMap.putAll(request.getSystemTags());
-       }
-       else{
-           logger.log("[GenerateTagsForCreate] CFN system tags are unexpectedly null for "
-                   + resourceModel.getArn());
-       }
-
         return tagMap;
     }
 

--- a/aws-resourceexplorer2-index/src/test/java/software/amazon/resourceexplorer2/index/CreateHandlerTest.java
+++ b/aws-resourceexplorer2-index/src/test/java/software/amazon/resourceexplorer2/index/CreateHandlerTest.java
@@ -29,6 +29,7 @@ import static software.amazon.resourceexplorer2.index.IndexUtils.AGGREGATOR;
 import static software.amazon.resourceexplorer2.index.IndexUtils.CREATING;
 import static software.amazon.resourceexplorer2.index.IndexUtils.LOCAL;
 import static software.amazon.resourceexplorer2.index.IndexUtils.UPDATING;
+import static software.amazon.resourceexplorer2.index.TestConstants.EMPTY_TAGS;
 import static software.amazon.resourceexplorer2.index.TestConstants.INDEX_ARN_1;
 import static software.amazon.resourceexplorer2.index.TestConstants.STACK_LEVEL_TAGS;
 import static software.amazon.resourceexplorer2.index.TestConstants.RESOURCE_TAGS;
@@ -204,7 +205,7 @@ public class CreateHandlerTest {
         List<ResourceExplorerRequest> invokedResourceExplorerRequest = capturedRequest.getAllValues();
 
         CreateIndexRequest invokedCreateIndexRequest = (CreateIndexRequest) invokedResourceExplorerRequest.get(0);
-        assertThat(invokedCreateIndexRequest.tags()).isEqualTo(SYSTEM_TAGS);
+        assertThat(invokedCreateIndexRequest.tags()).isEqualTo(EMPTY_TAGS);
 
         UpdateIndexTypeRequest invokedUpdateIndexTypeRequest = (UpdateIndexTypeRequest) invokedResourceExplorerRequest.get(1);
         assertThat(invokedUpdateIndexTypeRequest.arn()).isEqualTo(INDEX_ARN_1);
@@ -479,7 +480,7 @@ public class CreateHandlerTest {
         List<ResourceExplorerRequest> invokedResourceExplorerRequest = capturedRequest.getAllValues();
 
         CreateIndexRequest invokedCreateIndexRequest = (CreateIndexRequest) invokedResourceExplorerRequest.get(0);
-        assertThat(invokedCreateIndexRequest.tags()).isEqualTo(SYSTEM_TAGS);
+        assertThat(invokedCreateIndexRequest.tags()).isEqualTo(EMPTY_TAGS);
 
         UpdateIndexTypeRequest invokedUpdateIndexTypeRequest = (UpdateIndexTypeRequest) invokedResourceExplorerRequest.get(1);
         assertThat(invokedUpdateIndexTypeRequest.arn()).isEqualTo(INDEX_ARN_1);

--- a/aws-resourceexplorer2-index/src/test/java/software/amazon/resourceexplorer2/index/TestConstants.java
+++ b/aws-resourceexplorer2-index/src/test/java/software/amazon/resourceexplorer2/index/TestConstants.java
@@ -37,4 +37,6 @@ public class TestConstants {
         put("aws:cloudformation:stack-id", "STACKID");
         put("aws:cloudformation:stack-name", "UnitTesStack");
     }};
+
+    protected static final Map<String, String> EMPTY_TAGS = new HashMap<String, String>();
 }

--- a/aws-resourceexplorer2-view/src/main/java/software/amazon/resourceexplorer2/view/TagTools.java
+++ b/aws-resourceexplorer2-view/src/main/java/software/amazon/resourceexplorer2/view/TagTools.java
@@ -34,16 +34,6 @@ public class TagTools {
             tagMap.putAll(resourceModel.getTags());
         }
 
-        // CloudFormation System Tags (SystemTags) are automatically created,
-        // but we need to add them separately.
-        if (request.getSystemTags() != null) {
-            tagMap.putAll(request.getSystemTags());
-        }
-        else{
-            logger.log("[GenerateTagsForCreate] CFN system tags are unexpectedly null for "
-                    + resourceModel.getViewName());
-        }
-
         return tagMap;
     }
 

--- a/aws-resourceexplorer2-view/src/test/java/software/amazon/resourceexplorer2/view/CreateHandlerTest.java
+++ b/aws-resourceexplorer2-view/src/test/java/software/amazon/resourceexplorer2/view/CreateHandlerTest.java
@@ -116,7 +116,6 @@ public class CreateHandlerTest {
         expectedTags.putAll(RESOURCE_TAGS);
         expectedTags.putAll(STACK_LEVEL_TAGS);
 
-        expectedTags.putAll(SYSTEM_TAGS);
         assertThat(capturedRequestValue.tags()).containsExactlyEntriesOf(expectedTags);
 
     }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Remove CloudFormation system tag support from code.

This matches the model, which already listed CloudFormation system tags as unsupported (see [aws-resourceexplorer2-index.json](https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-resource-explorer/blob/main/aws-resourceexplorer2-index/aws-resourceexplorer2-index.json#L93) and [aws-resourceexplorer2-view.json](https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-resource-explorer/blob/main/aws-resourceexplorer2-view/aws-resourceexplorer2-view.json#L108)).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
