### PR TITLE
Modification to ADV CreateHandler to handle idempotent requests

### DIFF
--- a/aws-resourceexplorer2-defaultviewassociation/src/main/java/software/amazon/resourceexplorer2/defaultviewassociation/CallbackContext.java
+++ b/aws-resourceexplorer2-defaultviewassociation/src/main/java/software/amazon/resourceexplorer2/defaultviewassociation/CallbackContext.java
@@ -7,4 +7,5 @@ import software.amazon.cloudformation.proxy.StdCallbackContext;
 @lombok.ToString
 @lombok.EqualsAndHashCode(callSuper = true)
 public class CallbackContext extends StdCallbackContext {
+    boolean preExistenceCheck;
 }

--- a/aws-resourceexplorer2-defaultviewassociation/src/main/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandler.java
+++ b/aws-resourceexplorer2-defaultviewassociation/src/main/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandler.java
@@ -21,7 +21,6 @@ import software.amazon.awssdk.services.resourceexplorer2.model.GetDefaultViewRes
 public class CreateHandler extends REBaseHandler<CallbackContext> {
 
     private final ResourceExplorer2Client client;
-    private final int MAX_RETRIES = 3;
 
     public CreateHandler() {
         client = ClientFactory.getClient();

--- a/aws-resourceexplorer2-defaultviewassociation/src/main/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandler.java
+++ b/aws-resourceexplorer2-defaultviewassociation/src/main/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandler.java
@@ -86,7 +86,7 @@ public class CreateHandler extends REBaseHandler<CallbackContext> {
                 .resourceModel(model)
                 .status(OperationStatus.IN_PROGRESS)
                 .callbackContext(callbackContext)
-                .callbackDelaySeconds(30)
+                .callbackDelaySeconds(5)
                 .build();
     }
 }

--- a/aws-resourceexplorer2-defaultviewassociation/src/main/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandler.java
+++ b/aws-resourceexplorer2-defaultviewassociation/src/main/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandler.java
@@ -53,8 +53,12 @@ public class CreateHandler extends REBaseHandler<CallbackContext> {
         String viewArnFromResponse = getDefaultViewResponse.viewArn();
         // If a default view exists, and it is the desired default view, return AlreadyExist Error.
         if (viewArnFromResponse != null) {
-            if (callbackContext != null && callbackContext.preExistenceCheck && viewArnFromResponse.equals(model.getViewArn())) {
-                logger.log(String.format("[CREATE] A default view is already associated but not reporting failure as this is a CREATE retry."));
+            if (callbackContext != null && callbackContext.preExistenceCheck) {
+                logger.log(String.format("[CREATE] preExistenceCheck passed, proceed."));
+                return ProgressEvent.<ResourceModel, CallbackContext>builder()
+                    .resourceModel(model)
+                    .status(OperationStatus.SUCCESS)
+                    .build();
             } else {
                 logger.log(String.format("[CREATE] A default view is already associated."));
                 return ProgressEvent.failed(model, callbackContext, HandlerErrorCode.AlreadyExists, "A default view is already associated.");
@@ -80,7 +84,9 @@ public class CreateHandler extends REBaseHandler<CallbackContext> {
 
         return ProgressEvent.<ResourceModel, CallbackContext>builder()
                 .resourceModel(model)
-                .status(OperationStatus.SUCCESS)
+                .status(OperationStatus.IN_PROGRESS)
+                .callbackContext(callbackContext)
+                .callbackDelaySeconds(30)
                 .build();
     }
 }

--- a/aws-resourceexplorer2-defaultviewassociation/src/main/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandler.java
+++ b/aws-resourceexplorer2-defaultviewassociation/src/main/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandler.java
@@ -50,10 +50,17 @@ public class CreateHandler extends REBaseHandler<CallbackContext> {
 
         logger.log(String.format("[CREATE] Default view arn: " + getDefaultViewResponse.viewArn()));
 
+        String viewArnFromResponse = getDefaultViewResponse.viewArn();
         // If a default view exists, and it is the desired default view, return AlreadyExist Error.
-        if (getDefaultViewResponse.viewArn() != null){
-            logger.log(String.format("[CREATE] A default view is already associated."));
-            return ProgressEvent.failed(model, callbackContext, HandlerErrorCode.AlreadyExists, "A default view is already associated.");
+        if (viewArnFromResponse != null) {
+            if (callbackContext != null && callbackContext.preExistenceCheck && viewArnFromResponse.equals(model.getViewArn())) {
+                logger.log(String.format("[CREATE] A default view is already associated but not reporting failure as this is a CREATE retry."));
+            } else {
+                logger.log(String.format("[CREATE] A default view is already associated."));
+                return ProgressEvent.failed(model, callbackContext, HandlerErrorCode.AlreadyExists, "A default view is already associated.");
+            }
+        } else {
+            callbackContext.preExistenceCheck = true;
         }
 
         AssociateDefaultViewRequest associateDefaultViewRequest = AssociateDefaultViewRequest.builder()

--- a/aws-resourceexplorer2-defaultviewassociation/src/test/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandlerTest.java
+++ b/aws-resourceexplorer2-defaultviewassociation/src/test/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandlerTest.java
@@ -290,6 +290,7 @@ public class CreateHandlerTest {
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext()).isNotNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModel()).isNotNull();
         assertThat(response.getResourceModels()).isNull();

--- a/aws-resourceexplorer2-defaultviewassociation/src/test/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandlerTest.java
+++ b/aws-resourceexplorer2-defaultviewassociation/src/test/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandlerTest.java
@@ -82,12 +82,13 @@ public class CreateHandlerTest {
                 .awsAccountId(ACCOUNT_ID)
                 .build();
 
+        CallbackContext context = new CallbackContext();
+
         final ProgressEvent<ResourceModel, CallbackContext> response
-                = handler.handleRequest(proxy, request, null, logger);
+                = handler.handleRequest(proxy, request, context, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(response.getCallbackContext()).isNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModel()).isEqualTo(model.toBuilder().associatedAwsPrincipal(ACCOUNT_ID).build());
         assertThat(response.getResourceModels()).isNull();
@@ -250,12 +251,13 @@ public class CreateHandlerTest {
                 .awsAccountId(ACCOUNT_ID)
                 .build();
 
+        CallbackContext context = new CallbackContext();
+
         final ProgressEvent<ResourceModel, CallbackContext> response
-                = handler.handleRequest(proxy, request, null, logger);
+                = handler.handleRequest(proxy, request, context, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
-        assertThat(response.getCallbackContext()).isNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModel()).isNotNull();
         assertThat(response.getResourceModels()).isNull();

--- a/aws-resourceexplorer2-defaultviewassociation/src/test/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandlerTest.java
+++ b/aws-resourceexplorer2-defaultviewassociation/src/test/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandlerTest.java
@@ -53,7 +53,7 @@ public class CreateHandlerTest {
     // This test verifies the success status of setting up a default view while there is
     // no existed default view in an account.
     @Test
-    public void handleRequest_NonExistedDefaultView_Success() {
+    public void handleRequest_NonExistedDefaultView_Results_InProgress() {
 
         GetDefaultViewRequest getDefaultViewRequest = GetDefaultViewRequest.builder().build();
 

--- a/aws-resourceexplorer2-defaultviewassociation/src/test/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandlerTest.java
+++ b/aws-resourceexplorer2-defaultviewassociation/src/test/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandlerTest.java
@@ -124,15 +124,6 @@ public class CreateHandlerTest {
     @Test
     public void handleRequest_callbackContextIsSet() {
 
-        GetDefaultViewRequest getDefaultViewRequest = GetDefaultViewRequest.builder().build();
-
-        GetDefaultViewResponse getDefaultViewResponse = GetDefaultViewResponse.builder()
-                .viewArn(exampleArn1)
-                .build();
-
-        when(proxy.injectCredentialsAndInvokeV2(eq(getDefaultViewRequest), any()))
-                .thenReturn(getDefaultViewResponse);
-
         final ResourceModel model = ResourceModel.builder()
                 .viewArn(exampleArn1)
                 .build();
@@ -248,13 +239,6 @@ public class CreateHandlerTest {
     // This test throws InternalServerException when it invokes AssociateDefaultView.
     @Test
     public void handleRequest_throwInternalServerException() {
-
-        GetDefaultViewRequest getDefaultViewRequest = GetDefaultViewRequest.builder().build();
-
-        GetDefaultViewResponse getDefaultViewResponse = GetDefaultViewResponse.builder().build();
-
-        when(proxy.injectCredentialsAndInvokeV2(eq(getDefaultViewRequest), any()))
-                .thenReturn(getDefaultViewResponse);
 
         AssociateDefaultViewRequest associateDefaultViewRequest = AssociateDefaultViewRequest.builder()
                 .viewArn(exampleArn1)

--- a/aws-resourceexplorer2-defaultviewassociation/src/test/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandlerTest.java
+++ b/aws-resourceexplorer2-defaultviewassociation/src/test/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandlerTest.java
@@ -62,17 +62,6 @@ public class CreateHandlerTest {
         when(proxy.injectCredentialsAndInvokeV2(eq(getDefaultViewRequest), any()))
                 .thenReturn(getDefaultViewResponse);
 
-        AssociateDefaultViewRequest associateDefaultViewRequest = AssociateDefaultViewRequest.builder()
-                .viewArn(exampleArn1)
-                .build();
-
-        AssociateDefaultViewResponse associateDefaultViewResponse = AssociateDefaultViewResponse.builder()
-                .viewArn(exampleArn1)
-                .build();
-
-        when(proxy.injectCredentialsAndInvokeV2( eq(associateDefaultViewRequest), any()))
-                .thenReturn(associateDefaultViewResponse);
-
         final ResourceModel model = ResourceModel.builder()
                 .viewArn(exampleArn1)
                 .build();
@@ -91,7 +80,6 @@ public class CreateHandlerTest {
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackContext()).isNotNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(5);
-        assertThat(response.getResourceModel()).isEqualTo(model.toBuilder().associatedAwsPrincipal(ACCOUNT_ID).build());
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
@@ -160,6 +148,7 @@ public class CreateHandlerTest {
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getResourceModel()).isEqualTo(model.toBuilder().associatedAwsPrincipal(ACCOUNT_ID).build());
         assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
         assertThat(response.getResourceModels()).isNull();
     }
@@ -284,6 +273,7 @@ public class CreateHandlerTest {
                 .build();
 
         CallbackContext context = new CallbackContext();
+        context.preExistenceCheck = true;
 
         final ProgressEvent<ResourceModel, CallbackContext> response
                 = handler.handleRequest(proxy, request, context, logger);

--- a/aws-resourceexplorer2-defaultviewassociation/src/test/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandlerTest.java
+++ b/aws-resourceexplorer2-defaultviewassociation/src/test/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandlerTest.java
@@ -90,7 +90,7 @@ public class CreateHandlerTest {
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackContext()).isNotNull();
-        assertThat(response.getCallbackDelaySeconds()).isEqualTo(30);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(5);
         assertThat(response.getResourceModel()).isEqualTo(model.toBuilder().associatedAwsPrincipal(ACCOUNT_ID).build());
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();


### PR DESCRIPTION
*Issue #, if available:*
The AssociateDefaultView API is a configuration type API which associates a view as default. It attaches this information to the subscription of an AWS account. The API doesn't conflict, i.e. multiple calls are overriding, with same or different ViewArns. Sometimes, there is a problem in propagating responses from CFN handler to lambda because of which the handler retries. This subsequent call fails the contract test.

*Description of changes:*
Creating a call chain based approach to handle the idempotency problems with CREATE retries. This approach relies on doing a pre-existence check before actually calling CREATE. It sends an IN_PROGRESS status and when the handler retries if the pre-existence check flag is true, it ignores the error.

**This commit modifies the create handler as before the IN_PROGRESS status was sent after creation of resource. This would still cause problems because if the progress status has not reached the service, there will be no callback context and a duplicate request will cause failure.** 

*How are these changes tested?*
Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
