### PR TITLE
ADV create handler update to handle idempotency scenarios

### DIFF
--- a/aws-resourceexplorer2-defaultviewassociation/src/main/java/software/amazon/resourceexplorer2/defaultviewassociation/CallbackContext.java
+++ b/aws-resourceexplorer2-defaultviewassociation/src/main/java/software/amazon/resourceexplorer2/defaultviewassociation/CallbackContext.java
@@ -1,11 +1,10 @@
 package software.amazon.resourceexplorer2.defaultviewassociation;
 
-import software.amazon.cloudformation.proxy.StdCallbackContext;
+@lombok.Data
+@lombok.NoArgsConstructor
+@lombok.AllArgsConstructor
+@lombok.Builder
 
-@lombok.Getter
-@lombok.Setter
-@lombok.ToString
-@lombok.EqualsAndHashCode(callSuper = true)
-public class CallbackContext extends StdCallbackContext {
+public class CallbackContext {
     boolean preExistenceCheck;
 }

--- a/aws-resourceexplorer2-defaultviewassociation/src/main/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandler.java
+++ b/aws-resourceexplorer2-defaultviewassociation/src/main/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandler.java
@@ -53,7 +53,7 @@ public class CreateHandler extends REBaseHandler<CallbackContext> {
             final CallbackContext callbackContext,
             final Logger logger
         ) {
-       
+        logger.log(String.format("[CREATE] Inside method createResource, callbackContext: %s", callbackContext));
         AssociateDefaultViewRequest associateDefaultViewRequest = AssociateDefaultViewRequest.builder()
                 .viewArn(model.getViewArn())
                 .build();
@@ -80,26 +80,27 @@ public class CreateHandler extends REBaseHandler<CallbackContext> {
             final ResourceModel model,
             final Logger logger
         ) {
+            
             CallbackContext newCallbackContext = CallbackContext.builder()
                 .preExistenceCheck(true)
                 .build();
-            
+            logger.log(String.format("[CREATE][preExistenceCheck] executing preExistenceCheck, callbackContext: %s", newCallbackContext));
             GetDefaultViewRequest getDefaultViewRequest = GetDefaultViewRequest.builder().build();
             GetDefaultViewResponse getDefaultViewResponse;
             try {
                 getDefaultViewResponse = proxy.injectCredentialsAndInvokeV2( getDefaultViewRequest, client::getDefaultView );
+                model.setAssociatedAwsPrincipal(request.getAwsAccountId());
             } catch (Exception e){
-                logger.log(String.format("[CREATE] Error occurred in GetDefaultView."));
+                logger.log(String.format("[CREATE][preExistenceCheck] Error occurred in GetDefaultView."));
                 HandlerErrorCode thisErrorCode = Convertor.convertExceptionToErrorCode(e, logger);
                 return ProgressEvent.failed(model, newCallbackContext, thisErrorCode, "Could not check default view: " + e.getMessage());
             }
 
             if (getDefaultViewResponse.viewArn() != null) {
-                logger.log(String.format("[CREATE] A default view is already associated."));
+                logger.log(String.format("[CREATE][preExistenceCheck] A default view is already associated."));
                 return ProgressEvent.failed(model, newCallbackContext, HandlerErrorCode.AlreadyExists, "A default view is already associated.");
             }
             
-            createResource(proxy, model, request, newCallbackContext, logger);
             return ProgressEvent.defaultInProgressHandler(newCallbackContext, 1, model);
         }
     }

--- a/aws-resourceexplorer2-defaultviewassociation/src/main/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandler.java
+++ b/aws-resourceexplorer2-defaultviewassociation/src/main/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandler.java
@@ -80,9 +80,6 @@ public class CreateHandler extends REBaseHandler<CallbackContext> {
             final CallbackContext callbackContext,
             final Logger logger
         ) {
-            if (callbackContext != null && callbackContext.isPreExistenceCheck()) {
-                return ProgressEvent.progress(model, callbackContext);
-              }
             GetDefaultViewRequest getDefaultViewRequest = GetDefaultViewRequest.builder().build();
             GetDefaultViewResponse getDefaultViewResponse;
             try {
@@ -100,6 +97,6 @@ public class CreateHandler extends REBaseHandler<CallbackContext> {
             CallbackContext newCallbackContext = CallbackContext.builder()
                 .preExistenceCheck(true)
                 .build();
-            return ProgressEvent.progress(model, callbackContext);
+            return ProgressEvent.progress(model, newCallbackContext);
         }
     }

--- a/aws-resourceexplorer2-defaultviewassociation/src/main/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandler.java
+++ b/aws-resourceexplorer2-defaultviewassociation/src/main/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandler.java
@@ -37,8 +37,6 @@ public class CreateHandler extends REBaseHandler<CallbackContext> {
 
         final ResourceModel model = request.getDesiredResourceState();
         logger.log(String.format("[CREATE] callbackContext: %s", callbackContext));
-        System.out.println("callback: " + callbackContext);
-        System.out.println("callback2: " + (callbackContext != null && callbackContext.isPreExistenceCheck()));
         return ProgressEvent.progress(model, callbackContext)
             .then(
                 progress -> (callbackContext != null && callbackContext.isPreExistenceCheck())

--- a/aws-resourceexplorer2-defaultviewassociation/src/main/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandler.java
+++ b/aws-resourceexplorer2-defaultviewassociation/src/main/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandler.java
@@ -37,6 +37,8 @@ public class CreateHandler extends REBaseHandler<CallbackContext> {
 
         final ResourceModel model = request.getDesiredResourceState();
 
+        logger.log(String.format("[CREATE] callbackContext: " + callbackContext));
+
         if (callbackContext != null && callbackContext.preExistenceCheck) {
             // ADV API doesn't fail even if a view is already associated as default
             AssociateDefaultViewRequest associateDefaultViewRequest = AssociateDefaultViewRequest.builder()
@@ -71,15 +73,15 @@ public class CreateHandler extends REBaseHandler<CallbackContext> {
 
             logger.log(String.format("[CREATE] Default view arn: " + getDefaultViewResponse.viewArn()));
 
-            String viewArnFromResponse = getDefaultViewResponse.viewArn();
-
-            if (viewArnFromResponse == null) {
-                callbackContext.preExistenceCheck = true;
+            if (getDefaultViewResponse.viewArn() == null) {
+                CallbackContext newCallbackContext = CallbackContext.builder()
+                    .preExistenceCheck(true)
+                    .build();
                 return ProgressEvent.<ResourceModel, CallbackContext>builder()
                     .resourceModel(model)
                     .status(OperationStatus.IN_PROGRESS)
-                    .callbackContext(callbackContext)
-                    .callbackDelaySeconds(5)
+                    .callbackContext(newCallbackContext)
+                    .callbackDelaySeconds(30)
                     .build();
             } else {
                 logger.log(String.format("[CREATE] A default view is already associated."));

--- a/aws-resourceexplorer2-defaultviewassociation/src/test/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandlerTest.java
+++ b/aws-resourceexplorer2-defaultviewassociation/src/test/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandlerTest.java
@@ -79,7 +79,7 @@ public class CreateHandlerTest {
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackContext()).isNotNull();
-        assertThat(response.getCallbackDelaySeconds()).isEqualTo(5);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(30);
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();

--- a/aws-resourceexplorer2-defaultviewassociation/src/test/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandlerTest.java
+++ b/aws-resourceexplorer2-defaultviewassociation/src/test/java/software/amazon/resourceexplorer2/defaultviewassociation/CreateHandlerTest.java
@@ -71,9 +71,17 @@ public class CreateHandlerTest {
                 .awsAccountId(ACCOUNT_ID)
                 .build();
 
-        final ProgressEvent<ResourceModel, CallbackContext> response
+        
+        ProgressEvent<ResourceModel, CallbackContext> response
                 = handler.handleRequest(proxy, request, null, logger);
-
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(1);
+        CallbackContext context = CallbackContext.builder()
+                .preExistenceCheck(true)
+                .build();
+        response = handler.handleRequest(proxy, request, context, logger);
+        
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackContext()).isNull();
@@ -111,7 +119,7 @@ public class CreateHandlerTest {
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
-        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackContext()).isNotNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
         assertThat(response.getResourceModels()).isNull();
@@ -146,7 +154,7 @@ public class CreateHandlerTest {
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
-        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackContext()).isNotNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
         assertThat(response.getResourceModels()).isNull();
@@ -154,26 +162,26 @@ public class CreateHandlerTest {
         assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.AlreadyExists);
     }
 
-        // This test verifies the status of setting up the same default view already associated when idempotent.
+        // This test verifies the status of setting up the same default view already associated when idempotent retry.
         @Test
         public void handleRequest_preExistenceCheck_done() {
-    
-            final ResourceModel model = ResourceModel.builder()
-                    .viewArn(exampleArn1)
-                    .build();
-    
-            final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                    .desiredResourceState(model)
-                    .awsAccountId(ACCOUNT_ID)
-                    .build();
 
-           CallbackContext newCallbackContext = CallbackContext.builder()
-                    .preExistenceCheck(true)
-                    .build();
-    
-            final ProgressEvent<ResourceModel, CallbackContext> response
-                    = handler.handleRequest(proxy, request, newCallbackContext, logger);
-    
+                final ResourceModel model = ResourceModel.builder()
+                        .viewArn(exampleArn1)
+                        .build();
+
+                final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                        .desiredResourceState(model)
+                        .awsAccountId(ACCOUNT_ID)
+                        .build();
+
+                CallbackContext newCallbackContext = CallbackContext.builder()
+                        .preExistenceCheck(true)
+                        .build();
+
+                final ProgressEvent<ResourceModel, CallbackContext> response
+                        = handler.handleRequest(proxy, request, newCallbackContext, logger);
+
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackContext()).isNull();
@@ -203,7 +211,7 @@ public class CreateHandlerTest {
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
-        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackContext()).isNotNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModel()).isNotNull();
         assertThat(response.getResourceModels()).isNull();
@@ -232,7 +240,7 @@ public class CreateHandlerTest {
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
-        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackContext()).isNotNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModel()).isNotNull();
         assertThat(response.getResourceModels()).isNull();
@@ -265,7 +273,7 @@ public class CreateHandlerTest {
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
-        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackContext()).isNotNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModel()).isNotNull();
         assertThat(response.getResourceModels()).isNull();


### PR DESCRIPTION
*Issue #, if available:*
Handle Idempotency scenarios in ADV CREATE Handler

*Description of changes:*

Using call chain pattern in ADV CREATE handler. An IN_PROGRESS status is sent after doing a preExistence check with callbackDelay > 0 seconds. The handler does an idempotent retry and creates the resource in its next attempt.

The code is now split into two parts:
* preExistenceCheck: This method aims to check the status of resource before actually creating it. If a view is already associated as default, it fails with ALREADY_EXISTS, it passes otherwise. Although, if the preExistenceCheck flag is set to true in callbackContext, the error is ignored even if a view is already associated.
* Creation of resource: This method handles the actual association of defaultView. The underlying API doesn't conflict if there already exists a default view, as it is overriding. The failure can only happen in preExistenceCheck.

*Testing:*
Unit tests and contract tests (excluding LIST handler tests)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
