### PR TITLE
Adding Tag Permissions

### DIFF
--- a/aws-resourceexplorer2-index/aws-resourceexplorer2-index.json
+++ b/aws-resourceexplorer2-index/aws-resourceexplorer2-index.json
@@ -96,7 +96,12 @@
         "tagOnCreate": true,
         "cloudFormationSystemTags": false,
         "tagUpdatable": true,
-        "tagProperty": "/properties/Tags"
+        "tagProperty": "/properties/Tags",
+        "permissions": [
+            "resource-explorer-2:ListTagsForResource",
+            "resource-explorer-2:TagResource",
+            "resource-explorer-2:UntagResource"
+        ]
     },
     "additionalProperties": false
 }

--- a/aws-resourceexplorer2-view/aws-resourceexplorer2-view.json
+++ b/aws-resourceexplorer2-view/aws-resourceexplorer2-view.json
@@ -115,7 +115,12 @@
         "tagOnCreate": true,
         "cloudFormationSystemTags": false,
         "tagUpdatable": true,
-        "tagProperty": "/properties/Tags"
+        "tagProperty": "/properties/Tags",
+        "permissions": [
+            "resource-explorer-2:ListTagsForResource",
+            "resource-explorer-2:TagResource",
+            "resource-explorer-2:UntagResource"
+        ]
     },
     "additionalProperties": false
 }


### PR DESCRIPTION
Adding Tag Permissions for AWSCloudFormationResourceProvidersResourceExplorer

*Description of changes:*

Adding permissions to the tagging constructAWS::ResourceExplorer2::View and AWS::ResourceExplorer2::Index. 
