### PR TITLE
Make ResourceExplorer2Client Use amazonaws.com Endpoint

### DIFF
--- a/aws-resourceexplorer2-defaultviewassociation/src/main/java/software/amazon/resourceexplorer2/defaultviewassociation/ClientFactory.java
+++ b/aws-resourceexplorer2-defaultviewassociation/src/main/java/software/amazon/resourceexplorer2/defaultviewassociation/ClientFactory.java
@@ -19,7 +19,7 @@ public class ClientFactory {
 
         if(client == null) {
             client = ResourceExplorer2Client.builder()
-                    .endpointOverride(URI.create(String.format("https://resource-explorer-2.%s.api.aws", getRegion())))
+                    .endpointOverride(URI.create(String.format("https://resource-explorer-2.%s.amazonaws.com", getRegion())))
                     .region(Region.of(getRegion()))
                     .build();
         }

--- a/aws-resourceexplorer2-defaultviewassociation/src/main/java/software/amazon/resourceexplorer2/defaultviewassociation/ClientFactory.java
+++ b/aws-resourceexplorer2-defaultviewassociation/src/main/java/software/amazon/resourceexplorer2/defaultviewassociation/ClientFactory.java
@@ -19,7 +19,7 @@ public class ClientFactory {
 
         if(client == null) {
             client = ResourceExplorer2Client.builder()
-                    .endpointOverride(URI.create(String.format("https://resource-explorer-2.%s.amazonaws.com", getRegion())))
+                    .endpointOverride(URI.create(String.format("https://resource-explorer-2.%s.api.aws", getRegion())))
                     .region(Region.of(getRegion()))
                     .build();
         }

--- a/aws-resourceexplorer2-defaultviewassociation/src/main/java/software/amazon/resourceexplorer2/defaultviewassociation/ClientFactory.java
+++ b/aws-resourceexplorer2-defaultviewassociation/src/main/java/software/amazon/resourceexplorer2/defaultviewassociation/ClientFactory.java
@@ -19,7 +19,6 @@ public class ClientFactory {
 
         if(client == null) {
             client = ResourceExplorer2Client.builder()
-                    .endpointOverride(URI.create(String.format("https://resource-explorer-2.%s.api.aws", getRegion())))
                     .region(Region.of(getRegion()))
                     .build();
         }

--- a/aws-resourceexplorer2-index/src/main/java/software/amazon/resourceexplorer2/index/ClientFactory.java
+++ b/aws-resourceexplorer2-index/src/main/java/software/amazon/resourceexplorer2/index/ClientFactory.java
@@ -19,7 +19,7 @@ public class ClientFactory {
 
         if(client == null) {
             client = ResourceExplorer2Client.builder()
-                    .endpointOverride(URI.create(String.format("https://resource-explorer-2.%s.api.aws", getRegion())))
+                    .endpointOverride(URI.create(String.format("https://resource-explorer-2.%s.amazonaws.com", getRegion())))
                     .region(Region.of(getRegion()))
                     .build();
         }

--- a/aws-resourceexplorer2-index/src/main/java/software/amazon/resourceexplorer2/index/ClientFactory.java
+++ b/aws-resourceexplorer2-index/src/main/java/software/amazon/resourceexplorer2/index/ClientFactory.java
@@ -19,7 +19,7 @@ public class ClientFactory {
 
         if(client == null) {
             client = ResourceExplorer2Client.builder()
-                    .endpointOverride(URI.create(String.format("https://resource-explorer-2.%s.amazonaws.com", getRegion())))
+                    .endpointOverride(URI.create(String.format("https://resource-explorer-2.%s.api.aws", getRegion())))
                     .region(Region.of(getRegion()))
                     .build();
         }

--- a/aws-resourceexplorer2-index/src/main/java/software/amazon/resourceexplorer2/index/ClientFactory.java
+++ b/aws-resourceexplorer2-index/src/main/java/software/amazon/resourceexplorer2/index/ClientFactory.java
@@ -19,7 +19,6 @@ public class ClientFactory {
 
         if(client == null) {
             client = ResourceExplorer2Client.builder()
-                    .endpointOverride(URI.create(String.format("https://resource-explorer-2.%s.api.aws", getRegion())))
                     .region(Region.of(getRegion()))
                     .build();
         }

--- a/aws-resourceexplorer2-view/src/main/java/software/amazon/resourceexplorer2/view/ClientFactory.java
+++ b/aws-resourceexplorer2-view/src/main/java/software/amazon/resourceexplorer2/view/ClientFactory.java
@@ -19,7 +19,7 @@ public class ClientFactory {
 
         if(client == null) {
             client = ResourceExplorer2Client.builder()
-                    .endpointOverride(URI.create(String.format("https://resource-explorer-2.%s.api.aws", getRegion())))
+                    .endpointOverride(URI.create(String.format("https://resource-explorer-2.%s.amazonaws.com", getRegion())))
                     .region(Region.of(getRegion()))
                     .build();
         }

--- a/aws-resourceexplorer2-view/src/main/java/software/amazon/resourceexplorer2/view/ClientFactory.java
+++ b/aws-resourceexplorer2-view/src/main/java/software/amazon/resourceexplorer2/view/ClientFactory.java
@@ -19,7 +19,7 @@ public class ClientFactory {
 
         if(client == null) {
             client = ResourceExplorer2Client.builder()
-                    .endpointOverride(URI.create(String.format("https://resource-explorer-2.%s.amazonaws.com", getRegion())))
+                    .endpointOverride(URI.create(String.format("https://resource-explorer-2.%s.api.aws", getRegion())))
                     .region(Region.of(getRegion()))
                     .build();
         }

--- a/aws-resourceexplorer2-view/src/main/java/software/amazon/resourceexplorer2/view/ClientFactory.java
+++ b/aws-resourceexplorer2-view/src/main/java/software/amazon/resourceexplorer2/view/ClientFactory.java
@@ -19,7 +19,6 @@ public class ClientFactory {
 
         if(client == null) {
             client = ResourceExplorer2Client.builder()
-                    .endpointOverride(URI.create(String.format("https://resource-explorer-2.%s.api.aws", getRegion())))
                     .region(Region.of(getRegion()))
                     .build();
         }


### PR DESCRIPTION
Recently we found there are teams who are using CFN and everytime they deploy changes they are making calls to our APIs. These calls are coming to api.aws. As this is a blocker for IPv6 launch. We want to ensure, the endpoints are published via CFN.