### PR TITLE
update handler code for Index resource type to not rely on ListTagsFo…

### DIFF
--- a/aws-resourceexplorer2-index/pom.xml
+++ b/aws-resourceexplorer2-index/pom.xml
@@ -12,8 +12,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <cfn.generate.args/>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>[2.0.0,3.0.0)</version>
+            <version>2.0.7</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-resourceexplorer2-index/src/main/java/software/amazon/resourceexplorer2/index/UpdateHandler.java
+++ b/aws-resourceexplorer2-index/src/main/java/software/amazon/resourceexplorer2/index/UpdateHandler.java
@@ -26,6 +26,7 @@ import static software.amazon.resourceexplorer2.index.IndexUtils.UPDATING;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -173,7 +174,17 @@ public class UpdateHandler extends REBaseHandler<CallbackContext> {
         ResourceModel desiredModel = request.getDesiredResourceState();
 
         // First, we need to get the current tags of this Index by using ListTagsForResource.
-        Map<String, String> currentTags = listTags(proxy, desiredModel.getArn(), logger);
+        Map<String, String> currentTags = new HashMap<>();
+
+        Map<String, String> previousResourceTags = request.getPreviousResourceTags();
+        Map<String, String> previousSystemTags = request.getPreviousSystemTags();
+        Map<String, String> previousTags = null;
+        if (request.getPreviousResourceState()!=null)
+            previousTags = request.getPreviousResourceState().getTags();
+
+        if (previousResourceTags != null) currentTags.putAll(previousResourceTags);
+        if (previousSystemTags != null) currentTags.putAll(previousSystemTags);
+        if (previousTags != null) currentTags.putAll(previousTags);
 
         // Generate all types of desired tags into one map.
         Map<String,String> desiredTags = TagTools.combineAllTypesOfTags(desiredModel, request, logger);
@@ -211,9 +222,5 @@ public class UpdateHandler extends REBaseHandler<CallbackContext> {
 
     }
 
-    @VisibleForTesting
-    Map<String, String> listTags(AmazonWebServicesClientProxy proxy,
-                                 String indexArn, Logger logger){
-        return TagTools.listTagsForIndex(client, proxy, logger, indexArn);
-    }
+
 }

--- a/aws-resourceexplorer2-index/src/test/java/software/amazon/resourceexplorer2/index/UpdateHandlerTest.java
+++ b/aws-resourceexplorer2-index/src/test/java/software/amazon/resourceexplorer2/index/UpdateHandlerTest.java
@@ -93,9 +93,7 @@ public class UpdateHandlerTest {
                 .resourceArn(INDEX_ARN_1)
                 .build();
 
-        doReturn(ListTagsForResourceResponse.builder().tags(previousListTags).build())
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(eq(listTagsForResourceRequest), any());
+
 
         // Build GetIndexRequest and GetIndexResponse
         GetIndexRequest getIndexRequest = GetIndexRequest.builder().build();
@@ -132,6 +130,8 @@ public class UpdateHandlerTest {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(desiredModel)
+                .previousResourceTags(PRE_STACK_LEVEL_TAGS)
+                .previousSystemTags(SYSTEM_TAGS)
                 .build();
 
         final ProgressEvent<ResourceModel, CallbackContext> response
@@ -148,17 +148,16 @@ public class UpdateHandlerTest {
 
         // Capture the actual GetIndexRequest, UpdateIndexTypeRequest and UntagResourceRequest in the Update handler.
         ArgumentCaptor<ResourceExplorer2Request> capturedRequest = ArgumentCaptor.forClass(UpdateIndexTypeRequest.class);
-        verify(proxy, times(4)).injectCredentialsAndInvokeV2(capturedRequest.capture(), any());
+        verify(proxy, times(3)).injectCredentialsAndInvokeV2(capturedRequest.capture(), any());
         List<ResourceExplorer2Request> invokedResourceExplorer2Request = capturedRequest.getAllValues();
 
         UpdateIndexTypeRequest invokedUpdateIndexTypeRequest = (UpdateIndexTypeRequest) invokedResourceExplorer2Request.get(1);
         assertThat(invokedUpdateIndexTypeRequest.arn()).isEqualTo(desiredModel.getArn());
         assertThat(invokedUpdateIndexTypeRequest.typeAsString()).isEqualTo(desiredModel.getType());
 
-        ListTagsForResourceRequest invokedListTagsForResourceRequest = (ListTagsForResourceRequest) invokedResourceExplorer2Request.get(2);
-        assertThat(invokedListTagsForResourceRequest.resourceArn()).isEqualTo(desiredModel.getArn());
 
-        UntagResourceRequest invokedUntagResourceRequest = (UntagResourceRequest) invokedResourceExplorer2Request.get(3);
+
+        UntagResourceRequest invokedUntagResourceRequest = (UntagResourceRequest) invokedResourceExplorer2Request.get(2);
         assertThat(invokedUntagResourceRequest.resourceArn()).isEqualTo(desiredModel.getArn());
         assertThat(invokedUntagResourceRequest.tagKeys().size()).isEqualTo(1);
         assertThat(invokedUntagResourceRequest.tagKeys().get(0)).isEqualTo("StackLevelTag");
@@ -242,9 +241,7 @@ public class UpdateHandlerTest {
             putAll(SYSTEM_TAGS);
         }};
 
-        doReturn(previousListTags)
-                .when(handler)
-                .listTags(proxy, INDEX_ARN_1, logger);
+
 
         doReturn(GetIndexResponse.builder().arn(INDEX_ARN_1).type(AGGREGATOR)
                 .state(ACTIVE)
@@ -265,6 +262,8 @@ public class UpdateHandlerTest {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(desiredModel)
+                .previousResourceTags(PRE_STACK_LEVEL_TAGS)
+                .previousSystemTags(SYSTEM_TAGS)
                 .build();
 
         final ProgressEvent<ResourceModel, CallbackContext> response
@@ -272,7 +271,6 @@ public class UpdateHandlerTest {
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(response.getCallbackContext()).isNull();
         assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
@@ -396,9 +394,7 @@ public class UpdateHandlerTest {
             putAll(SYSTEM_TAGS);
         }};
 
-        doReturn(previousListTags)
-                .when(handler)
-                .listTags(proxy, INDEX_ARN_1, logger);
+
 
         // Build GetIndexRequest and GetIndexResponse
         GetIndexRequest getIndexRequest = GetIndexRequest.builder().build();
@@ -422,6 +418,8 @@ public class UpdateHandlerTest {
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(desiredModel)
                 .desiredResourceTags(STACK_LEVEL_TAGS)
+                .previousResourceTags(PRE_STACK_LEVEL_TAGS)
+                .previousSystemTags(SYSTEM_TAGS)
                 .systemTags(SYSTEM_TAGS)
                 .build();
 
@@ -430,7 +428,6 @@ public class UpdateHandlerTest {
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(response.getCallbackContext()).isNull();
         assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();


### PR DESCRIPTION
…rResource

*Issue #, if available:*
We need to stop relying on ListTagsForResource and instead rely on states passed from CFN in update handler. 

*Description of changes:*
move away from api call and read from request object. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
